### PR TITLE
Trims `match` to support space between curly braces

### DIFF
--- a/content/helpers/placeholders.md
+++ b/content/helpers/placeholders.md
@@ -35,7 +35,7 @@ var placeholders = function (template, data) {
 		match = match.slice(2, -2);
 
 		// Get the value
-		var val = get(data, match);
+		var val = get(data, match.trim());
 
 		// Replace
 		if (!val) return '{{' + match + '}}';


### PR DESCRIPTION
Really nice set of functions. I only added this tiny change to allow placeholders like `{{ greetings }}`.