### PR TITLE
Fix .slice() demo typo

### DIFF
--- a/content/reference/strings/string-slice.md
+++ b/content/reference/strings/string-slice.md
@@ -19,7 +19,7 @@ var text = 'Cape Cod potato chips';
 // returns "Cod potato chips"
 text.slice(5);
 
-// returns "Code"
+// returns "Cod"
 text.slice(5, 8);
 
 // returns "Cape Cod potato"


### PR DESCRIPTION
Just ran in to this reviewing your excellent reference resource. Looks like this was just a little typo!