### PR TITLE
fix: Added missing case for minutes

### DIFF
--- a/content/helpers/timeFromNow.md
+++ b/content/helpers/timeFromNow.md
@@ -59,7 +59,7 @@ function timeFromNow (time) {
 		tfn.time = Math.floor(difference / (60 * 60));
 	} else if (difference / 60 > 1) {
 		// Minutes
-		tfn.unitOfTime = 'hours';
+		tfn.unitOfTime = 'minutes';
 		tfn.time = Math.floor(difference / 60);
 	} else {
 		// Seconds

--- a/content/helpers/timeFromNow.md
+++ b/content/helpers/timeFromNow.md
@@ -57,6 +57,10 @@ function timeFromNow (time) {
 		// Hours
 		tfn.unitOfTime = 'hours';
 		tfn.time = Math.floor(difference / (60 * 60));
+	} else if (difference / 60 > 1) {
+		// Minutes
+		tfn.unitOfTime = 'hours';
+		tfn.time = Math.floor(difference / 60);
 	} else {
 		// Seconds
 		tfn.unitOfTime = 'seconds';


### PR DESCRIPTION
### Motivation

When using the timeFromNow function, the unitOfTime property would display "seconds" although the amount of seconds is to big. This PR fixes that by adding an extra unitOfTime value "minutes". 
